### PR TITLE
Clipboard-Button hinzugefügt

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -245,7 +245,7 @@ const Rexstan = {
                 this.__targetNode = document.querySelector(this.__target);
             }
             if (!this.__targetNode) {
-                console.error('Invalid attribute `target="' + this.__target + '"`, search failed');
+                console.warn('Invalid attribute `target="' + this.__target + '"`, search failed');
             }
             return this.__targetNode;
         }
@@ -542,7 +542,7 @@ customElements.define('rexstan-analysis',
  *  - Bei Änderungen der Header-Höhe des Haupt-Header (der mit dem Suchfeld) muss der
  *    Stopp-Punkt des eigenen Headers angepasst werden 
  *    (über Event rexstan:headersize)
- *  - Bendet die Messages ein oder aus (Bootstrap-collapse) wenn angefordert
+ *  - Blendet die Messages ein oder aus (Bootstrap-collapse) wenn angefordert
  *    (über Event rexstan:collapse)
  *  - speichert den aktuellen Collapse-Status in der Session
  *    (über Bootstrap-Events getriggert)
@@ -675,6 +675,7 @@ customElements.define('rexstan-message',
             }
             super.connectedCallback();
             this.addEventListener('rexstan:tip', this._toggleTip.bind(this));
+            this.addEventListener('rexstan:clipboard', this._toClipboard.bind(this));
         }
 
         childrenAvailableCallback() {
@@ -688,6 +689,7 @@ customElements.define('rexstan-message',
         disconnectedCallback() {
             this.__root.removeEventListener(Rexstan.evtSearch, this._applySearch.bind(this));
             this.removeEventListener('rexstan:tip', this._toggleTip.bind(this));
+            this.removeEventListener('rexstan:clipboard', this._toClipboard.bind(this));
         }
 
         _applySearch(event) {
@@ -710,6 +712,9 @@ customElements.define('rexstan-message',
 
         _toggleTip(event) {
             this.classList.toggle('rexstan-tip-closed');
+        }
+        _toClipboard(event) {
+            navigator.clipboard.writeText(`\'${event.detail}\'`);
         }
     }
 );

--- a/fragments/analysis_items.php
+++ b/fragments/analysis_items.php
@@ -31,6 +31,8 @@ use function array_key_exists;
 use function dirname;
 use function is_int;
 
+use const DIRECTORY_SEPARATOR;
+
 /** @var rex_fragment $this */
 
 /** @var string $link */
@@ -65,11 +67,10 @@ foreach ($result['messages'] as $message) {
 
     $text = rex_escape($message['message']);
     $url = $editor->getUrl($link, $message['line']);
+    $pasteButton = '<rexstan-trigger class="btn btn-xs btn-default" event="rexstan:clipboard" detail="' . $text . '"title="' . rex_i18n::msg('igor_rexstan_analysis_clipboard') . '"><i class="fa fa-clipboard"></i></rexstan-trigger> ';
 
-    if (null === $url) {
-        $text = '<span class="rexstan-message-text">' . $text . '</span>';
-    } else {
-        $text = '<a class="rexstan-message-text" href="' . $url . '">' . $text . '</a>';
+    if (null !== $url) {
+        $text = '<a href="' . $url . '">' . $text . '</a>';
     }
 
     $ignoreClass = $message['ignorable'] ? '' : ' text-danger';
@@ -77,7 +78,7 @@ foreach ($result['messages'] as $message) {
     $content .= '<rexstan-message class="' . $tipClass . '">';
     $content .= '<span class="rexstan-line-number' . $ignoreClass . '">' . $message['line'] . ':</span>';
     $content .= '<rexstan-trigger class="btn btn-xs btn-default btn-tip" event="rexstan:tip" title="' . rex_i18n::msg('igor_rexstan_analysis_tip') . '"><i class="fa fa-lightbulb-o"></i></rexstan-trigger> ';
-    $content .= $text;
+    $content .= '<span class="rexstan-message-text">' . $pasteButton . $text . '</span>';
     $content .= $tip;
     $content .= '</rexstan-message>';
 }

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -51,3 +51,4 @@ igor_rexstan_analysis_success = Gratulation, es wurden keine Fehler in Level {0}
 igor_rexstan_analysis_nextlevel = In den <a href="{0}">Einstellungen</a>, solltest du jetzt das nächste Level anvisieren.
 igor_rexstan_analysis_tip = Tip anzeigen/ausblenden
 igor_rexstan_analysis_refresh = Neu analysieren
+igor_rexstan_analysis_clipboard = Fehlermeldung kopieren (Clipboard)


### PR DESCRIPTION
Per Button die Fehlermeldung als String `'fehlermeldung'` an das Clipboard heften. 

Wofür: vereinfachtes Kopieren der Fehlermeldung in einen Kommentar im Code.